### PR TITLE
Add: 이벤트 버블링 & stopPropagation

### DIFF
--- a/css/bubbing.css
+++ b/css/bubbing.css
@@ -1,0 +1,39 @@
+.container {
+  width: 100vw;
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+h1 {
+  text-align: center;
+}
+
+.products {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-evenly;
+  gap: 30px;
+}
+
+.img {
+  width: 250px;
+  height: 260px;
+  position: relative;
+  background-position: center;
+  background-size: cover;
+}
+
+.cart {
+  width: 60px;
+  height: 60px;
+  border-radius: 50%;
+  background-color: white;
+  position: absolute;
+  bottom: 10px;
+  right: 10px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  font-size: 24px;
+}

--- a/html/bubbling.html
+++ b/html/bubbling.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <script
+      src="https://kit.fontawesome.com/20ab5899a1.js"
+      crossorigin="anonymous"
+    ></script>
+    <link rel="stylesheet" href="../css/bubbing.css" />
+    <title>Bubbling</title>
+  </head>
+  <body>
+    <div class="container">
+      <h1>Event Bubbling</h1>
+      <div class="products"></div>
+    </div>
+    <script src="../js/bubbling.js"></script>
+  </body>
+</html>

--- a/js/bubbling.js
+++ b/js/bubbling.js
@@ -1,0 +1,29 @@
+const products = document.querySelector(".products");
+
+const imgs = [
+  "https://images.unsplash.com/photo-1582131503261-fca1d1c0589f?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=687&q=80",
+  "https://images.unsplash.com/photo-1581783342308-f792dbdd27c5?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=687&q=80",
+  "https://images.unsplash.com/photo-1554577621-1a3def0b656c?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=686&q=80",
+  "https://images.unsplash.com/photo-1581783342308-f792dbdd27c5?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=687&q=80",
+  "https://images.unsplash.com/photo-1631125915902-d8abe9225ff2?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=687&q=80",
+  "https://images.unsplash.com/photo-1529136490842-e2da7a4c7b74?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=642&q=80",
+];
+
+const paintImg = (src) => {
+  const img = document.createElement("div");
+  img.style.backgroundImage = `url(${src})`;
+  img.className = "img";
+  img.addEventListener("click", () => {
+    alert("상품 상세페이지로 이동합니다!");
+  });
+  const cart = document.createElement("i");
+  cart.className = "cart fa-solid fa-cart-shopping";
+  cart.addEventListener("click", (event) => {
+    event.stopPropagation();
+    alert("장바구니로 이동합니다!");
+  });
+  img.appendChild(cart);
+  products.appendChild(img);
+};
+
+imgs.forEach((img) => paintImg(img));


### PR DESCRIPTION
## Event Bubbling
HTML 문서의 계층적 구조 특징 때문에 자식에서 이벤트가 발생하게 되면 부모에게 까지 연속적으로 이벤트가 흘러 올라가게 된다.
![이벤트 버블링](https://user-images.githubusercontent.com/117281717/232691751-199493da-e1b6-43b9-bac4-5948256ef3f0.gif)
위와 예시를 보면 상품을 클릭하면 상세페이지로 이동하고 장바구니 버튼을 클릭하면 장바구니로 이동해야한다. 
하지만 장바구니 버튼을 클릭하면 상품과 장바구니 버튼 모두 클릭이벤트를 등록해두었기 때문에 장바구니 버튼을 클릭하면 장바구니 버튼에 등록해두었던 동작과 그 부모에 등록해두었던 동작까지 함께 작동하는 것을 볼 수 있다.
<br>
이를 막기 위한 메서드로 **stopPropagation()**이라는 메서드가 있다.
![stopPropagation](https://user-images.githubusercontent.com/117281717/232692949-d7b70e0e-8794-4692-8781-11c7f3f5af66.gif)
위는 장바구니 버튼에 stopPropagation()을 적용한 것이다. 
장바구니 버튼을 클릭 했을 때 부모에 등록해두었던 동작은 일어나지 않는다.