### PR TITLE
Add: 이벤트 위임

### DIFF
--- a/css/delegation.css
+++ b/css/delegation.css
@@ -1,0 +1,26 @@
+.container {
+  width: 100vw;
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+ul {
+  width: 350px;
+  display: flex;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 15px;
+  list-style: none;
+}
+
+li {
+  width: 100px;
+  height: 100px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  font-size: 50px;
+  background-color: antiquewhite;
+}

--- a/html/delegation.html
+++ b/html/delegation.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="stylesheet" href="../css/delegation.css" />
+    <title>delegation</title>
+  </head>
+  <body>
+    <div class="container">
+      <h1>이벤트 위임</h1>
+      <ul>
+        <li>🐶</li>
+        <li>🐱</li>
+        <li>🐭</li>
+        <li>🐹</li>
+        <li>🐰</li>
+        <li>🦊</li>
+        <li>🐻</li>
+        <li>🐼</li>
+        <li>🐻‍❄️</li>
+      </ul>
+    </div>
+    <script src="../js/delegation.js"></script>
+  </body>
+</html>

--- a/js/delegation.js
+++ b/js/delegation.js
@@ -1,0 +1,7 @@
+const ul = document.querySelector("ul");
+
+ul.addEventListener("click", (e) => {
+  if (e.target.tagName === "LI") {
+    alert(e.target.innerText);
+  }
+});


### PR DESCRIPTION
## 이벤트 위임
이벤트 버블링을 활용하여 조금 더 코드를 간결하고 메모리가 절약될 수 있는 방법이 바로 이벤트 위임이다.
이벤트 위임은 **상위 요소에서 하위 요소의 이벤트를 제어하는 방식**이다.
<br>
이벤트 위임을 하면 하위 요소마다 핸들러를 등록하지 않고 상위 요소에 하나의 이벤트 핸들러를 할당하여 하위 요소를 핸들링 할 수 있다.
![이벤트 위임](https://user-images.githubusercontent.com/117281717/232698146-c7f69051-8dd7-4096-9697-6e441a87329c.gif)
위는 이벤트 위임의 예시이다. 
ul 태그안의 여러개의 li 태그를 클릭 했을 때 해당 태그의 innerText를 alert로 띄우는 것이다.
li 태그 하나하나 이벤트를 등록하는 방법도 있지만 이벤트 위임을 통해 ul 태그에만 이벤트 핸들러를 등록하여 모든 작업이 가능했다.
<br>
하지만 li 태그 사이사이에 빈 공간을 클릭하면 ul 태그가 선택되어 ul 태그가 가지고 있는 모든 innerText 가 alert 창에 띄워지는 것을 볼 수 있다.
그래서 조건문을 통해 tagName 이 li 라면 alert 창에 띄워주도록 설정했다.
단, tagName은 항상 대문자 문자열만 가지는 점은 유의하자!
![tagName](https://user-images.githubusercontent.com/117281717/232699268-cc16af55-a913-4e93-bcd3-962c4029c895.gif)