### PR TITLE
이벤트 버블링 모달 예시 구현완료

### DIFF
--- a/css/capturing.css
+++ b/css/capturing.css
@@ -1,0 +1,49 @@
+#container {
+  width: 100vw;
+  height: 100vh;
+  position: relative;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+button {
+  all: unset;
+  width: 200px;
+  height: 80px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background-color: #679289;
+  border-radius: 15px;
+  color: white;
+  font-weight: bold;
+  font-size: 24px;
+}
+
+.modal {
+  position: fixed;
+  width: 100%;
+  height: 100%;
+  top: 0;
+  left: 0;
+  background-color: rgba(0, 0, 0, 0.6);
+}
+
+.modalContent {
+  width: 500px;
+  height: 350px;
+  position: absolute;
+  top: 25%;
+  left: 35%;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  background-color: white;
+  border-radius: 15px;
+}
+
+.hidden {
+  display: none;
+}

--- a/html/capturing.html
+++ b/html/capturing.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="stylesheet" href="../css/capturing.css" />
+    <title>Event Capturing</title>
+  </head>
+  <body>
+    <div id="container">
+      <button class="openBtn">모달창 열기 👊</button>
+      <div class="modal hidden">
+        <div class="modalContent">
+          <h1>모달창입니다! 🙏</h1>
+          <button class="closeBtn">모달창 닫기 ❌</button>
+        </div>
+      </div>
+    </div>
+    <script src="../js/capturing.js"></script>
+  </body>
+</html>

--- a/js/capturing.js
+++ b/js/capturing.js
@@ -1,0 +1,21 @@
+const openBtn = document.querySelector(".openBtn");
+const modal = document.querySelector(".modal");
+const modalContent = document.querySelector(".modalContent");
+const closeBtn = document.querySelector(".closeBtn");
+
+const HIDDEN_CLASSNAME = "hidden";
+
+const openModal = () => {
+  modal.classList.remove(HIDDEN_CLASSNAME);
+};
+
+const closeModal = () => {
+  modal.classList.add(HIDDEN_CLASSNAME);
+};
+
+openBtn.addEventListener("click", openModal);
+closeBtn.addEventListener("click", closeModal);
+modal.addEventListener("click", closeModal);
+modalContent.addEventListener("click", (e) => {
+  e.stopPropagation();
+});


### PR DESCRIPTION
## 모달창 만들기
모달창을 만드는데에는 많은 방법이 있지만 이벤트 버블링을 이용해 모달창을 구현해보았다.

![이벤트 버블링 - modal](https://user-images.githubusercontent.com/117281717/233767704-eec73391-d249-4845-a8d7-186bc2ab64fd.gif)

### 모달창 닫기
모달창 닫기 버튼을 눌렀을 때와 검은 바탕을 클릭했을 때 모두 모달창이 닫혀야했다.
```html
// html
 <div class="modal hidden">
    <div class="modalContent">
        <h1>모달창입니다! 🙏</h1>
        <button class="closeBtn">모달창 닫기 ❌</button>
    </div>
</div>
```
```js
// js
const modal = document.querySelector(".modal");
const modalContent = document.querySelector(".modalContent");
const closeBtn = document.querySelector(".closeBtn");

const HIDDEN_CLASSNAME = "hidden";

const closeModal = () => {
  modal.classList.add(HIDDEN_CLASSNAME);
};

closeBtn.addEventListener("click", closeModal);
modal.addEventListener("click", closeModal);
modalContent.addEventListener("click", (e) => {
  e.stopPropagation();
});
```
뒤의 배경인 modal 에 이벤트를 달면 자동으로 흰 배경인 modalContent 를 클릭했을 때도 모달창이 닫아지는 현상이 발생한다.
따라서 modalContent에 stopPropagation 메서드를 추가해 해당 동작이 작동하지 않도록 막았다.